### PR TITLE
fix(runcmd): change docker listening port addition

### DIFF
--- a/roles/micado-master/files/misc/runcmd.sh
+++ b/roles/micado-master/files/misc/runcmd.sh
@@ -50,7 +50,7 @@ add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(
 apt-get update
 apt-get install -y docker-ce=17.09.1~ce-0~ubuntu
 export IP=$(hostname -I | cut -d\  -f1)
-sed -i -e "s/-H fd:\/\//-H fd:\/\/ -H tcp:\/\/$IP:2375/g" /lib/systemd/system/docker.service
+sed -i -e "s/-H fd:\/\/.*$/-H fd:\/\/ -H tcp:\/\/$IP:2375/g" /lib/systemd/system/docker.service
 systemctl daemon-reload
 service docker restart
 # Install Docker Compose


### PR DESCRIPTION
Change how the listening port is added to the docker systemd
unit file to avoid duplications on successive runs