### PR TITLE
Image names, visualizer and hosts

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,1 +1,1 @@
-micado-master ansible_host=IP ansible_connection=ssh
+micado-master ansible_host=localhost ansible_connection=local ansible_user=ubuntu ansible_become=True ansible_become_method=sudo

--- a/micado-master.yml
+++ b/micado-master.yml
@@ -1,8 +1,6 @@
+---
 - name: Deploy MiCADO master (and spawn a worker...)
   hosts: micado-master
-  user: ubuntu
-  connection: ssh # or ssh or paramiko
-  become: true
 
   pre_tasks:
     - name: Verify Ansible meets the version requirements (>=2.2).
@@ -18,3 +16,12 @@
     - docker_package: docker-ce=17.09.1~ce-0~ubuntu
     - docker_compose_version: 1.16.1
     - docker_compose_pip_version: pip
+    - docker_images:
+        submitter: micado/micado-submitter:1.1
+        redis: redis
+        occopus: micado/occopus:1.6-rc1
+        consul: consul:1.0.0
+        prometheus: prom/prometheus:v2.1.0
+        alertmanager: prom/alertmanager:v0.12.0
+        policykeeper: micado/policykeeper:0.1-dev-frame
+        dockervisualizer: jaydes/dockerviz:min-refresh

--- a/roles/micado-master/tasks/docker-pull-images.yml
+++ b/roles/micado-master/tasks/docker-pull-images.yml
@@ -1,0 +1,34 @@
+---
+
+- name: 'Downloading docker image: Redis'
+  docker_image:
+      name: "{{docker_images.redis}}"
+
+- name: 'Downloading docker image: Consul'
+  docker_image:
+      name: "{{docker_images.consul}}"
+
+- name: 'Downloading docker image: Prometheus'
+  docker_image:
+      name: "{{docker_images.prometheus}}"
+
+- name: 'Downloading docker image: Alertmanager'
+  docker_image:
+      name: "{{docker_images.alertmanager}}"
+
+- name: 'Downloading docker image: Docker Visualizer'
+  docker_image:
+      name: "{{docker_images.dockervisualizer}}"
+
+- name: 'Downloading docker image: Submitter'
+  docker_image:
+      name: "{{docker_images.submitter}}"
+
+- name: 'Downloading docker image: Policykeeper'
+  docker_image:
+      name: "{{docker_images.policykeeper}}"
+
+- name: 'Downloading docker image: Occopus'
+  docker_image:
+      name: "{{docker_images.occopus}}"
+

--- a/roles/micado-master/tasks/main.yml
+++ b/roles/micado-master/tasks/main.yml
@@ -37,5 +37,7 @@
 
 - include: worker_node.yml
 
+- include: docker-pull-images.yml
+
 - name: "Run runcmd.sh script #FIXME"
   script: files/misc/runcmd.sh

--- a/roles/micado-master/templates/docker/docker-compose.yml.j2
+++ b/roles/micado-master/templates/docker/docker-compose.yml.j2
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
    submitter:
-     image: micado/micado-submitter:1.1
+     image: {{docker_images.submitter}}
      container_name: micado-submitter
      volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
@@ -24,7 +24,7 @@ services:
      command: python /app/submitter/submitter.py
 
    redis:
-    image: redis
+    image: {{docker_images.redis}}
     container_name: occopus_redis
     restart: always
     volumes:
@@ -32,7 +32,7 @@ services:
     command: redis-server --appendonly yes
 
    occopus:
-    image: micado/occopus:1.6-rc1
+    image: {{docker_images.occopus}}
     container_name: occopus
     depends_on:
       - redis
@@ -48,7 +48,7 @@ services:
     command: occopus-rest-service --auth_data_path /var/lib/micado/occopus/data/auth_data.yaml --host 0.0.0.0
 
    consul:
-    image: consul:1.0.0
+    image: {{docker_images.consul}}
     container_name: consul
     restart: always
     ports:
@@ -66,7 +66,7 @@ services:
     command: agent -server -client=0.0.0.0 -advertise={{ ansible_default_ipv4.address }} -bootstrap=true -ui
 
    prometheus:
-    image: prom/prometheus:v2.1.0
+    image: {{docker_images.prometheus}}
     container_name: prometheus
     restart: always
     depends_on:
@@ -79,7 +79,7 @@ services:
     command: '--config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles --web.enable-lifecycle'
 
    alertmanager:
-    image: prom/alertmanager:v0.12.0
+    image: {{docker_images.alertmanager}}
     container_name: alertmanager
     depends_on:
       - prometheus
@@ -90,7 +90,7 @@ services:
       - "/var/lib/micado/alertmanager/data/:/alertmanager/"
 
    policykeeper:
-    image: micado/policykeeper:0.1-dev-frame
+    image: {{docker_images.policykeeper}}
     container_name: policykeeper
     depends_on:
       - occopus
@@ -102,4 +102,13 @@ services:
       - "/var/lib/micado/policykeeper/config/:/config/policykeeper"
       - "/var/lib/micado/prometheus/config/:/config/prometheus"
     command: /policykeeper/policy_keeper.py --srv --cfg /config/policykeeper/policykeeper_config.yaml
+
+   dockervisualizer:
+    image: {{docker_images.dockervisualizer}}
+    container_name: dockervisualizer
+    ports:
+      - 8080:8080
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    command: npm start
 

--- a/update-ansible.yml
+++ b/update-ansible.yml
@@ -1,8 +1,5 @@
 - name: Update Ansible
   hosts: micado-master
-  user: ubuntu
-  connection: ssh # or ssh or paramiko
-  become: true
 
   roles:
     - update-ansible


### PR DESCRIPTION
- move docker image names to ansible variable in micado-master.yml
- download docker images separately
- apply docker image names in compose file
- add dockervisualizer to micado master compose
- move user, become and become-method settings to hosts from .yml files