### PR TITLE
Integrate ToscaSubmitter into playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ At the end of the deployment, core MiCADO services will be running on the MiCADO
 ## Monitoring
 
 MiCADO exposes the following webpages:
-- Prometheus: 
+- Prometheus:
 ```http://IP:9090```
 - Docker visualizer:
 ```http://IP:8080```
@@ -84,7 +84,7 @@ MiCADO exposes the following webpages:
 You can find test application(s) under the subdirectories of the 'testing' directory.
 
 - stressng
- 
+
   This application contains a single service, performing constant load. Policy defined for this application scales up/down both nodes and the stressng service based on cpu consumption. Both compose and policy files are ready to be submitted with the helper scripts:
   - Step1: set the MICADO_MASTER variable to contain the IP of the MiCADO master
   - Step2: run ```1-deploy-stressng.sh``` to deploy the stressng service
@@ -94,6 +94,10 @@ You can find test application(s) under the subdirectories of the 'testing' direc
   - Step6: run ```4-stop-scaling-policy-stressng.sh``` to deactivate the monitoring/scaling components
   - Step7: optionally, run ```curl -s -X POST http://$MICADO_MASTER:5000/infrastructures/micado_worker_infra/scaleto/worker/1``` to scale MiCADO workers back to their minimal count
 
-
-
-
+  Optional steps for testing TOSCA submission of stressng:
+  - Step1: set the MICADO_MASTER variable to contain the IP of the MiCADO master
+  - Step2: run ```5-tosca-submit-stressng.sh``` to deploy the stressng service based on https://raw.githubusercontent.com/jaydesl/COLARepo/master/examples/stressng.yaml
+  - Step3: Edit ```policy-stressng.yaml``` and change the constant service name to include the id of the deployment (ie. SERVICE_FULL_NAME: '<app_id>_stressng')
+  - Step4: run ```2-start-scaling-policy-stressng.sh``` to activate the monitoring/scaling components
+  - Step5: run ```6-undeploy-with-id.sh <app_id>``` to remove the stressng service
+  - Step6: run ```4-stop-scaling-policy-stressng.sh``` to deactivate the monitoring/scaling components

--- a/micado-master.yml
+++ b/micado-master.yml
@@ -27,3 +27,4 @@
         policykeeper: micado/policykeeper:0.1-dev-frame
         dockervisualizer: jaydes/dockerviz:min-refresh
         grafana: grafana/grafana:5.1.0
+        toscasubmitter: jaydes/toscasubmitter:ansible

--- a/micado-master.yml
+++ b/micado-master.yml
@@ -27,4 +27,4 @@
         policykeeper: micado/policykeeper:0.1-dev-frame
         dockervisualizer: jaydes/dockerviz:min-refresh
         grafana: grafana/grafana:5.1.0
-        toscasubmitter: jaydes/toscasubmitter:ansible_rest
+        toscasubmitter: micado/toscasubmitter:0.1

--- a/micado-master.yml
+++ b/micado-master.yml
@@ -27,4 +27,4 @@
         policykeeper: micado/policykeeper:0.1-dev-frame
         dockervisualizer: jaydes/dockerviz:min-refresh
         grafana: grafana/grafana:5.1.0
-        toscasubmitter: jaydes/toscasubmitter:ansible
+        toscasubmitter: jaydes/toscasubmitter:ansible_rest

--- a/roles/micado-master/files/toscasubmitter/key_config.yml
+++ b/roles/micado-master/files/toscasubmitter/key_config.yml
@@ -1,0 +1,17 @@
+config:
+  dry_run: False
+  path_log: "/var/lib/submitter/submitter.log"
+
+Adaptor_config:
+ DummySeAdaptor:
+   types:
+     - "tosca.policies.Scaling.*"
+   endoint: "endpoint"
+   volume: "/var/lib/submitter/security_workdir_example/"
+
+
+ DockerAdaptor:
+   types:
+     - "tosca.nodes.MiCADO.Container.Application.Docker"
+   endoint: "endpoint"
+   volume: "/var/lib/submitter/files/output_configs/"

--- a/roles/micado-master/files/worker_node/cloud_init_worker.yaml
+++ b/roles/micado-master/files/worker_node/cloud_init_worker.yaml
@@ -16,7 +16,7 @@ write_files:
     "encrypt": "uohStneoKEoVYZIASGp6Nw==",
     "log_level": "INFO",
     "enable_syslog": false,
-    "retry_join": ["{{variables.master_host_ip}}"], 
+    "retry_join": ["{{variables.master_host_ip}}"],
     "rejoin_after_leave": true,
     "services": [{"name":"worker_cluster","port":9100}, {"name":"app_docker_cluster","port":9200}]
     }
@@ -36,7 +36,7 @@ write_files:
 
     rm -rf /etc/resolvconf/*
     echo "Setup NETWORK finished."
-  
+
 
 - path: /etc/resolvconf/resolv.conf.d/base
   content: |
@@ -93,9 +93,10 @@ runcmd:
   - line=127.0.1.1'\t'$new_host_name
   - sed -i "s/$oldhostname/$new_host_name/g" /etc/hosts
   - echo $line >> /etc/hosts
-  - export DEBIAN_FRONTEND=noninteractive 
+  - export DEBIAN_FRONTEND=noninteractive
   - dpkg-reconfigure openssh-server
   - resolvconf -u
+  - echo nameserver 8.8.8.8 >> /etc/resolv.conf
 # Docker
   - apt-get update
   - apt-get install -y --no-install-recommends apt-transport-https ca-certificates curl software-properties-common wget unzip
@@ -116,6 +117,5 @@ runcmd:
   - export IP=$(hostname -I | cut -d\  -f1)
   - docker-compose -f /etc/micado/docker-compose.yml up -d
 #  - sudo docker run -d -p 9100:9100 prom/node-exporter:v0.15.2
-#  - sudo docker run -d --net=host -e 'CONSUL_LOCAL_CONFIG={"leave_on_terminate":true}' -p 8301:8301 -p 8301:8301/udp -p 8300:8300 -p 8302:8302 -p 8302:8302/udp -p 8400:8400 -p 8500:8500 -p 8600:8600/udp -v /etc/consul/:/etc/consul consul:1.0.0 agent -advertise=$IP -retry-join={{variables.master_host_ip}} -config-file=/etc/consul/config.json 
+#  - sudo docker run -d --net=host -e 'CONSUL_LOCAL_CONFIG={"leave_on_terminate":true}' -p 8301:8301 -p 8301:8301/udp -p 8300:8300 -p 8302:8302 -p 8302:8302/udp -p 8400:8400 -p 8500:8500 -p 8600:8600/udp -v /etc/consul/:/etc/consul consul:1.0.0 agent -advertise=$IP -retry-join={{variables.master_host_ip}} -config-file=/etc/consul/config.json
 #  - sudo docker run  --volume=/:/rootfs:ro  --volume=/var/run:/var/run:rw  --volume=/sys:/sys:ro  --volume=/var/lib/docker/:/var/lib/docker:ro  --publish=9200:8080  --detach=true  --name=cadvisor google/cadvisor:v0.28.3
-

--- a/roles/micado-master/tasks/docker-pull-images.yml
+++ b/roles/micado-master/tasks/docker-pull-images.yml
@@ -36,3 +36,6 @@
   docker_image:
       name: "{{docker_images.occopus}}"
 
+- name: 'Downloading docker image: ToscaSubmitter'
+  docker_image:
+      name: "{{docker_images.toscasubmitter}}"

--- a/roles/micado-master/tasks/files.yml
+++ b/roles/micado-master/tasks/files.yml
@@ -102,10 +102,20 @@
     dest: /var/lib/micado/grafana/provisioning/datasources/prometheus.yaml
     mode: 0644
 
+- name: "TOSCAsubmitter config: Create working directory"
+  file:
+    path: /var/lib/toscasubmitter/system
+    state: directory
+    mode: 0775
+    recurse: yes
+- name: "TOSCAsubmitter config: Copy config file"
+  copy:
+    src: toscasubmitter/key_config.yml
+    dest: /var/lib/toscasubmitter/system/key_config.yml
+    mode: 0644
+
 - name: "Docker-compose: Copy file"
   template:
     src: docker/docker-compose.yml.j2
     dest: /var/lib/micado/docker-compose.yml
     mode: 0644
-
-

--- a/roles/micado-master/templates/docker/docker-compose.yml.j2
+++ b/roles/micado-master/templates/docker/docker-compose.yml.j2
@@ -124,3 +124,11 @@ services:
       - "/var/lib/micado/grafana/provisioning:/etc/grafana/provisioning"
     user: "root"
 
+   toscasubmitter:
+    image: {{docker_images.toscasubmitter}}
+    container_name: toscasubmitter
+    ports:
+      - 5050:5050
+    command: ["-h 0.0.0.0", "-p 5050"]
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"

--- a/roles/micado-master/templates/docker/docker-compose.yml.j2
+++ b/roles/micado-master/templates/docker/docker-compose.yml.j2
@@ -132,4 +132,6 @@ services:
     command: "-h 0.0.0.0 -p 5050"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
+      - "/var/lib/toscasubmitter/system:/var/lib/submitter/system/"
+      - "/var/lib/toscasubmitter/outputs:/var/lib/submitter/files/output_configs"
     user: "root"

--- a/roles/micado-master/templates/docker/docker-compose.yml.j2
+++ b/roles/micado-master/templates/docker/docker-compose.yml.j2
@@ -129,6 +129,7 @@ services:
     container_name: toscasubmitter
     ports:
       - 5050:5050
-    command: ["-h 0.0.0.0", "-p 5050"]
+    command: "-h 0.0.0.0 -p 5050"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
+    user: "root"

--- a/testing/stressng/5-tosca-submit-stressng.sh
+++ b/testing/stressng/5-tosca-submit-stressng.sh
@@ -1,0 +1,13 @@
+if [ -z "$MICADO_MASTER" ]; then
+    if [[ $# -eq 0 ]] ; then
+        echo 'Please, specify the ip address or set MICADO_MASTER!'
+        exit 1
+    fi
+    if [[ $# -gt 1 ]] ; then
+        echo 'Please, specify only one ip address!'
+        exit 1
+    fi
+    MICADO_MASTER=$1
+fi
+
+curl -d input="https://raw.githubusercontent.com/jaydesl/COLARepo/master/examples/stressng.yaml" -X POST http://$MICADO_MASTER:5050/engine/

--- a/testing/stressng/6-undeploy-with-id.sh
+++ b/testing/stressng/6-undeploy-with-id.sh
@@ -1,0 +1,14 @@
+if [ -z "$MICADO_MASTER" ]; then
+    if [[ $# -eq 0 ]] ; then
+       echo 'Please, specify the app_id AND ip address (or set MICADO_MASTER!)'
+       exit 1
+    fi
+    if [[ $# -gt 2 ]] ; then
+       echo 'Please, specify only one ip address!'
+       exit 1
+    fi
+    MICADO_MASTER=$2
+fi
+ID_APP=$1
+
+curl -d id_app=$ID_APP -X POST http://$MICADO_MASTER:5050/undeploy/

--- a/testing/stressng/6-undeploy-with-id.sh
+++ b/testing/stressng/6-undeploy-with-id.sh
@@ -11,4 +11,4 @@ if [ -z "$MICADO_MASTER" ]; then
 fi
 ID_APP=$1
 
-curl -d id_app=$ID_APP -X POST http://$MICADO_MASTER:5050/undeploy/
+curl -X DELETE http://$MICADO_MASTER:5050/undeploy/$ID_APP

--- a/testing/stressng/7-list-apps.sh
+++ b/testing/stressng/7-list-apps.sh
@@ -10,4 +10,4 @@ if [ -z "$MICADO_MASTER" ]; then
     MICADO_MASTER=$2
 fi
 
-curl -X GET http://$MICADO_MASTER:5050/list_app/
+curl -X GET http://$MICADO_MASTER:5050/list_app

--- a/testing/stressng/7-list-apps.sh
+++ b/testing/stressng/7-list-apps.sh
@@ -1,0 +1,13 @@
+if [ -z "$MICADO_MASTER" ]; then
+    if [[ $# -eq 0 ]] ; then
+       echo 'Please, specify the master ip address (or set MICADO_MASTER!)'
+       exit 1
+    fi
+    if [[ $# -gt 2 ]] ; then
+       echo 'Please, specify only one ip address!'
+       exit 1
+    fi
+    MICADO_MASTER=$2
+fi
+
+curl -X GET http://$MICADO_MASTER:5050/list_app/

--- a/testing/stressng/8-tosca-update-stressng.sh
+++ b/testing/stressng/8-tosca-update-stressng.sh
@@ -11,4 +11,4 @@ if [ -z "$MICADO_MASTER" ]; then
 fi
 ID_APP=$1
 
-curl -d input="https://raw.githubusercontent.com/jaydesl/COLARepo/master/examples/stressng_update.yaml" -X PUT http://$MICADO_MASTER:5050/update/$ID_APP
+curl -d input="https://raw.githubusercontent.com/COLAProject/COLARepo/master/examples/stressng_update.yaml" -X PUT http://$MICADO_MASTER:5050/update/$ID_APP

--- a/testing/stressng/8-tosca-update-stressng.sh
+++ b/testing/stressng/8-tosca-update-stressng.sh
@@ -1,0 +1,14 @@
+if [ -z "$MICADO_MASTER" ]; then
+    if [[ $# -eq 0 ]] ; then
+        echo 'Please, specify the app_id AND ip address (or set MICADO_MASTER!)'
+        exit 1
+    fi
+    if [[ $# -gt 1 ]] ; then
+        echo 'Please, specify only one ip address!'
+        exit 1
+    fi
+    MICADO_MASTER=$2
+fi
+ID_APP=$1
+
+curl -d input="https://raw.githubusercontent.com/jaydesl/COLARepo/master/examples/stressng_update.yaml" -X PUT http://$MICADO_MASTER:5050/update/$ID_APP


### PR DESCRIPTION
The ToscaSubmitter API endpoint can be specified in the playbook's docker-compose file
  * modify "ports" and "command"

The compose file also mounts volumes to persist the config file and docker-compose outputs

The ToscaSubmitter config file is found in "files/key_config.yml"
  * specify log path, which adaptors to use, and any configurable data for specific adaptors (including endpoints, workdir, etc.....)

