### PR TITLE
Do not fail on missing docker_cred_path

### DIFF
--- a/roles/micado-master/tasks/main.yml
+++ b/roles/micado-master/tasks/main.yml
@@ -12,3 +12,4 @@
 - include: start_micado.yml
 
 - include: docker-login.yml
+  when: docker_cred_path is defined


### PR DESCRIPTION
Fix #59 