### PR TITLE
Disable Unatt. Upgrades on worker nodes

### DIFF
--- a/roles/micado-master/templates/worker_node/cloud_init_worker.yaml.j2
+++ b/roles/micado-master/templates/worker_node/cloud_init_worker.yaml.j2
@@ -96,6 +96,7 @@ write_files:
 
 runcmd:
   - /tmp/wait-updates.sh
+  - sed -i 's/APT::Periodic::Unattended-Upgrade "1";/APT::Periodic::Unattended-Upgrade "0";/g' /etc/apt/apt.conf.d/20auto-upgrades
   - /bin/consul-set-network.sh
   - IP=`ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | sed 's/\./-/g'`
   - hostname={{ worker_hostname }}-$IP


### PR DESCRIPTION
**(FIX)** Workers will sometimes start unattended upgrades. These will run alongside any running apps and steal resources. In **stressng** tests for example, containers are unable to produce the required CPU and therefore do not generate *service_overloaded* alerts.