### PR TITLE
Modify execution order of TOSCA adaptors

### DIFF
--- a/roles/micado-master/files/toscasubmitter/key_config.yml
+++ b/roles/micado-master/files/toscasubmitter/key_config.yml
@@ -9,17 +9,17 @@ step:
     - OccopusAdaptor
     - PkAdaptor
   execute:
-    - DockerAdaptor
     - OccopusAdaptor
+    - DockerAdaptor
     - PkAdaptor
   update:
-    - DockerAdaptor
     - OccopusAdaptor
+    - DockerAdaptor
     - PkAdaptor
   undeploy:
+    - PkAdaptor
     - DockerAdaptor
     - OccopusAdaptor
-    - PkAdaptor
   cleanup:
     - DockerAdaptor
     - OccopusAdaptor


### PR DESCRIPTION
This order is more logical. 

* Docker containers need a VM to run on, so Occopus should execute first. Ditto update
* The PK will continue to fire scaling requests at both Docker & Occopus until it is undeployed, so it should come down first