### PR TITLE
Improve security, stability & reliability in K8s

### DIFF
--- a/micado-master.yml
+++ b/micado-master.yml
@@ -103,4 +103,4 @@
         docker_ce: "docker-ce=5:19.03.1~3-0~ubuntu-{{ ansible_distribution_release }}"
         docker_ce_cli: "docker-ce-cli=5:19.03.1~3-0~ubuntu-{{ ansible_distribution_release }}"
         containerd_io: containerd.io=1.2.6-3
-        kubernetes_version: 1.15.2-00
+        kubernetes_version: 1.15.3-00

--- a/roles/build-micado-master/tasks/docker-install.yml
+++ b/roles/build-micado-master/tasks/docker-install.yml
@@ -40,7 +40,7 @@
   lineinfile:
     dest: /lib/systemd/system/docker.service
     regexp: '^ExecStart=/usr/bin/dockerd[.]?'
-    line: "ExecStart=/usr/bin/dockerd -H fd:// --mtu={{ ansible_default_ipv4.mtu }}"
+    line: "ExecStart=/usr/bin/dockerd -H fd:// --exec-opt native.cgroupdriver=systemd --mtu={{ ansible_default_ipv4.mtu }}"
   register: docker_service
 
 - name: 'Docker: Copy log options'

--- a/roles/start-micado-master/tasks/kubernetes-start.yml
+++ b/roles/start-micado-master/tasks/kubernetes-start.yml
@@ -46,6 +46,22 @@
     regexp: 'cgroupDriver: cgroupfs'
     replace: 'cgroupDriver: systemd'
 
+- name: 'Kubernetes: Make node updates less frequent'
+  replace:
+    path: /var/lib/kubelet/config.yaml
+    regexp: 'nodeStatusUpdateFrequency: \d+s'
+    replace: 'nodeStatusUpdateFrequency: 20s'
+
+- name: 'Kubernetes: Lower pod eviction timeout'
+  lineinfile:
+    path: /var/lib/kubelet/config.yaml
+    line: 'podEvictionTimeout: 2m0s'
+
+- name: 'Kubernetes: Extend node monitor grace period'
+  lineinfile:
+    path: /var/lib/kubelet/config.yaml
+    line: 'nodeMonitorGracePeriod: 2m0s'
+
 - name: 'Kubernetes: Restart Kubelet'
   service:
     name: kubelet

--- a/roles/start-micado-master/tasks/kubernetes-start.yml
+++ b/roles/start-micado-master/tasks/kubernetes-start.yml
@@ -40,6 +40,12 @@
     regexp: 'nodefs.available: \d+%'
     replace: 'nodefs.available: 5%'
 
+- name: 'Kubernetes: Change cgroup driver'
+  replace:
+    path: /var/lib/kubelet/config.yaml
+    regexp: 'cgroupDriver: cgroupfs'
+    replace: 'cgroupDriver: systemd'
+
 - name: 'Kubernetes: Restart Kubelet'
   service:
     name: kubelet


### PR DESCRIPTION
* Update Kubernetes to v1.15.3 (CVE-2019-9512 and CVE-2019-9514)
  * https://groups.google.com/forum/#!topic/kubernetes-security-announce/wlHLHit1BqA
* Change Docker & Kubernetes cGroup driver to systemd
  * https://github.com/kubernetes/kubeadm/issues/1394#issuecomment-462878219
* Slow down pod/node eviction process
  * https://github.com/kubernetes-sigs/kubespray/blob/master/docs/kubernetes-reliability.md#medium-update-and-average-reaction