### PR TITLE
Fix: Pin kubernetes-client ~=11.0.0

### DIFF
--- a/roles/micado_master/build/tasks/python-install.yml
+++ b/roles/micado_master/build/tasks/python-install.yml
@@ -10,11 +10,11 @@
   pip:
     name:
     - setuptools<45
-    - pip
-    - docker
-    - kubernetes
-    - openshift
-    - requests
-    - click
-    - terminaltables
+    - pip<21
+    - docker~=4.3.0
+    - kubernetes~=11.0.0
+    - openshift~=0.11.0
+    - requests~=2.22.0
+    - click<8
+    - terminaltables<4
     state: present


### PR DESCRIPTION
Fix an issue related to an incompatibility between Ansible module `community.kubernetes<=1.1.1` and Python `kubernetes-client>=12.0.0`.

See ansible-collections/community.kubernetes/issues/273