### PR TITLE
Restructure cloud-credentials file

### DIFF
--- a/roles/micado_master/start/files/egi/configure
+++ b/roles/micado_master/start/files/egi/configure
@@ -1,6 +1,4 @@
 # OpenStack settings:
-export EGI_SITE={{ egi_site }}
-
 export OS_PROTOCOL="openid"
 export OS_PROJECT_ID="{{ project_id }}"
 export OS_AUTH_URL="https://sbgcloud.in2p3.fr:5000/v3"

--- a/roles/micado_master/start/files/egi/configure
+++ b/roles/micado_master/start/files/egi/configure
@@ -1,15 +1,15 @@
 # OpenStack settings:
 export OS_PROTOCOL="openid"
 export OS_PROJECT_ID="{{ project_id }}"
-export OS_AUTH_URL="https://sbgcloud.in2p3.fr:5000/v3"
+export OS_AUTH_URL="{{ auth_url }}"
 export OS_IDENTITY_API_VERSION=3
-export OS_IDENTITY_PROVIDER=egi.eu
+export OS_IDENTITY_PROVIDER="{{ identity_provider }}"
 export OS_AUTH_TYPE="v3oidcaccesstoken"
 
 # EGI AAI Check-In settings:
 export CHECKIN_CLIENT_ID="{{ client_id }}"
 export CHECKIN_CLIENT_SECRET="{{ client_secret }}"
 export CHECKIN_REFRESH_TOKEN="{{ refresh_token }}"
-export CHECKIN_AUTH_URL="https://aai.egi.eu/oidc/token"
+export CHECKIN_AUTH_URL="{{ oidc_url }}"
 
 export OS_TOKEN=$(python3 /var/lib/micado/terraform/submitter/pyGetScopedToken.py)

--- a/sample-credentials-cloud-api.yml
+++ b/sample-credentials-cloud-api.yml
@@ -1,3 +1,12 @@
+pre_authentication:
+- type: openid
+  auth_data: &OPENID
+    # Use this anchor for pre-authenticating with OpenID Connect refresh token 
+    url:
+    client_id:
+    client_secret:
+    refresh_token:
+
 resource:
 - type: ec2
   auth_data:
@@ -17,12 +26,15 @@ resource:
 - type: nova
   auth_data:
     # Select your authentication method
-    # Optional
+    # v3.Password
     username: 
     password:
-    # Optional
+    # v3.ApplicationCredential
     application_credential_id:
     application_credential_secret:
+    # v3.OidcAccessToken
+    identity_provider:
+    access_token: # Literal token or the OPENID alias: *OPENID
 
 - type: azure
   auth_data:

--- a/sample-credentials-cloud-api.yml
+++ b/sample-credentials-cloud-api.yml
@@ -1,54 +1,53 @@
 resource:
-  -
-    type: ec2
-    auth_data:
-        accesskey: 
-        secretkey: 
-  -
-     type: cloudsigma
-     auth_data:
-        email: 
-        password: 
-  -
-     type: cloudbroker
-     auth_data:
-        email: 
-        password: 
-  -
-     type: nova
-     auth_data:
-        # Select your authentication method
-        # Optional
-        username: 
-        password:
-        # Optional
-        application_credential_id:
-        application_credential_secret:
-  -
-     type: azure
-     auth_data:
-        # Select your authentication method
-        # Only subscription_id is required for auth with Managed Service Identity
-        subscription_id:
-        # Optional (additional parameters for auth with Service Principal)
-        client_id:
-        client_secret:
-        tenant_id:
-  -
-     type: oci
-     auth_data:
-        # Select your authentication method
-        # Fill these parameters ONLY if you are using API Key based authentication
-        tenancy_ocid:
-        user_ocid:
-        fingerprint:
-  -
-     type: egi
-     auth_data:
-        client_id:
-        client_secret:
-        egi_site:
-        os_project_id:
-        refresh_token:
+- type: ec2
+  auth_data:
+    accesskey: 
+    secretkey: 
+
+- type: cloudsigma
+  auth_data:
+    email:
+    password:
+
+- type: cloudbroker
+  auth_data:
+    email: 
+    password: 
+
+- type: nova
+  auth_data:
+    # Select your authentication method
+    # Optional
+    username: 
+    password:
+    # Optional
+    application_credential_id:
+    application_credential_secret:
+
+- type: azure
+  auth_data:
+    # Select your authentication method
+    # Only subscription_id is required for auth with Managed Service Identity
+    subscription_id:
+    # Optional (additional parameters for auth with Service Principal)
+    client_id:
+    client_secret:
+    tenant_id:
+
+- type: oci
+  auth_data:
+    # Select your authentication method
+    # Fill these parameters ONLY if you are using API Key based authentication
+    tenancy_ocid:
+    user_ocid:
+    fingerprint:
+
+- type: egi
+  auth_data:
+    client_id:
+    client_secret:
+    egi_site:
+    os_project_id:
+    refresh_token:
 
 # For authentication with Google Cloud, populate the credentials-gce.json file


### PR DESCRIPTION
### Split the `egi` entry
#### Some properties move under `nova` and some move to `OPENID` (new entry)

Reasoning:
* `egi_site` (ie. `identity_provider`) and `access_token` are properties of OpenStack authentication with an OpenID Connect access token
* `client_id` `client_secret` and `refresh_token` are not used to authenticate with OpenStack, only to fetch the access token from an OpenID provider
* `egi`/`access_token` can now be provided if known, otherwise use the `OPENID` placeholder reference and fill the `OPENID` entry