### PR TITLE
refactor: lookup micado cred var

### DIFF
--- a/playbook/project/host_vars/micado.yml
+++ b/playbook/project/host_vars/micado.yml
@@ -44,3 +44,4 @@ min_ubuntu: ["18.04", "20.04"]
 # lookups
 # -------------------------------------------------------
 oci_key: '{{ lookup("file", "{{ oci_key_path }}") }}'
+security: '{{ lookup("file", "{{ micado_cred_path }}", errors="ignore") }}'

--- a/playbook/project/roles/micado_master/start/tasks/security-config.yml
+++ b/playbook/project/roles/micado_master/start/tasks/security-config.yml
@@ -1,10 +1,4 @@
 ---
-- name: '(Ansible) Load the security settings from the playbook'
-  include_vars:
-    file: "{{ micado_cred_path  }}"
-    name: security
-  when: security_cred_file.stat.exists
-
 - name: '(MiCADO Security) Copy config templates'
   template:
     src: "{{ item.src }}"


### PR DESCRIPTION
Change MiCADO credential handling from include_vars: to lookup(). To improve the micado-client experience.